### PR TITLE
Fix logic to search for data to allow packaging with conda.

### DIFF
--- a/molmod/context.py
+++ b/molmod/context.py
@@ -31,6 +31,7 @@
 
 
 import os
+import sys
 
 
 __all__ = ["Context", "context"]
@@ -45,13 +46,13 @@ class Context(object):
            to do this manually a second time.
         """
         # find the data files
-        fn_datadir = os.path.join(os.path.dirname(__file__), "datadir.txt")
-        if os.path.isfile(fn_datadir):
-            f = file(fn_datadir)
-            datadir = f.readline().strip()
-            f.close()
-            self.data_dir = os.path.join(datadir, "share", "molmod")
-        else:
+        datadir = sys.prefix
+        self.data_dir = os.path.join(datadir, "share", "molmod")
+        try:
+            direc_exists = os.path.isdir(self.data_dir)
+        except OSError:
+            direc_exists = False
+        if not direc_exists:
             # When running from the build directory for the tests.
             self.data_dir = os.path.join(os.path.dirname(__file__), "../data")
         if not os.path.isdir(self.data_dir):

--- a/setup.py
+++ b/setup.py
@@ -31,26 +31,11 @@ from distutils.command.install_data import install_data
 
 
 class MyInstallData(install_data):
-    """Add a datadir.txt file that points to the root for the data files. It is
-       otherwise impossible to figure out the location of these data files at
-       runtime.
+    """Ensure data is store at root-level
     """
     def run(self):
         # Do the normal install_data
         install_data.run(self)
-        # Create the file datadir.txt. It's exact content is only known
-        # at installation time.
-        dist = self.distribution
-        libdir = dist.command_obj["install_lib"].install_dir
-        for name in dist.packages:
-            if '.' not in name:
-                destination = os.path.join(libdir, name, "datadir.txt")
-                print "Creating %s" % destination
-                if not self.dry_run:
-                    f = file(destination, "w")
-                    print >> f, self.install_dir
-                    f.close()
-
 
 setup(
     name='molmod',


### PR DESCRIPTION
This pull requests changes the run-time mechanism for finding the data directory to use sys.prefix instead of the hard-coded datadir.txt file

This allows easy packaging with conda.
