### PR TITLE
Prepare for Python 3.8 migration 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 env:
   matrix:
   - MYCONDAPY=2.7
-  - MYCONDAPY=3.6
   - MYCONDAPY=3.7
+  - MYCONDAPY=3.8
   global:
     # ANACONDA_TOKEN
     - secure: "Mict7gfK9EflyXN0wgMIEcW3jErzwWo+xtU7U5I8Rb/zFyKyXiBwTqbq6l6zlvmTR8/Yj8H5RG70+vHigMTRyMQttRtpa9Y8Uu/hGLkTEC5/QIhbqKbRLNOY2xzkwgQ7H+DHsi2z03cbYrM78rFUNwL0cvIPnUO4PEHLosa9ZK4="

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,15 @@ language: generic
 os:
   - linux
   - osx
-osx_image: xcode10.1
+osx_image: xcode9.4
 dist: trusty
 sudo: false
+
+# Same problem as described here: https://github.com/brian-team/brian2/issues/1128
+jobs:
+  allow_failures:
+    - python: "2.7"
+      os: osx
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ env:
   matrix:
   - MYCONDAPY=2.7
   - MYCONDAPY=3.7
-  - MYCONDAPY=3.8
   global:
     # ANACONDA_TOKEN
     - secure: "Mict7gfK9EflyXN0wgMIEcW3jErzwWo+xtU7U5I8Rb/zFyKyXiBwTqbq6l6zlvmTR8/Yj8H5RG70+vHigMTRyMQttRtpa9Y8Uu/hGLkTEC5/QIhbqKbRLNOY2xzkwgQ7H+DHsi2z03cbYrM78rFUNwL0cvIPnUO4PEHLosa9ZK4="
@@ -18,7 +17,7 @@ language: generic
 os:
   - linux
   - osx
-osx_image: xcode6.4
+osx_image: xcode9.4
 dist: trusty
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ language: generic
 os:
   - linux
   - osx
-osx_image: xcode9.4
+osx_image: xcode10.1
 dist: trusty
 sudo: false
 

--- a/molmod/log.py
+++ b/molmod/log.py
@@ -388,11 +388,11 @@ class Timer(object):
 
     def start(self):
         assert self._start is None
-        self._start = time.clock()
+        self._start = time.process_time()
 
     def stop(self):
         assert self._start is not None
-        self.cpu += time.clock() - self._start
+        self.cpu += time.process_time() - self._start
         self._start = None
 
 

--- a/molmod/log.py
+++ b/molmod/log.py
@@ -29,7 +29,10 @@ import os
 import platform
 import datetime
 import getpass
-import time
+try:
+    from time import process_time
+except ImportError:
+    from time import clock as process_time
 import codecs
 import locale
 import functools
@@ -388,11 +391,11 @@ class Timer(object):
 
     def start(self):
         assert self._start is None
-        self._start = time.process_time()
+        self._start = process_time()
 
     def stop(self):
         assert self._start is not None
-        self.cpu += time.process_time() - self._start
+        self.cpu += process_time() - self._start
         self._start = None
 
 

--- a/molmod/minimizer.py
+++ b/molmod/minimizer.py
@@ -63,7 +63,10 @@
 from __future__ import print_function, division
 
 from builtins import range
-import time
+try:
+    from time import process_time
+except ImportError:
+    from time import clock as process_time
 
 import numpy as np
 
@@ -1414,7 +1417,7 @@ class Minimizer(object):
             except ConstraintError:
                 self._screen("CONSTRAINT PROJECT FAILED", newline=True)
                 return False
-        self.last_end = time.process_time()
+        self.last_end = process_time()
 
     def propagate(self):
         # compute the new direction
@@ -1474,7 +1477,7 @@ class Minimizer(object):
         else:
             converged = False
         # timing
-        end = time.process_time()
+        end = process_time()
         self._screen("%5.2f" % (end - self.last_end), newline=True)
         self.last_end = end
         # check convergence, part 2

--- a/molmod/minimizer.py
+++ b/molmod/minimizer.py
@@ -1414,7 +1414,7 @@ class Minimizer(object):
             except ConstraintError:
                 self._screen("CONSTRAINT PROJECT FAILED", newline=True)
                 return False
-        self.last_end = time.clock()
+        self.last_end = time.process_time()
 
     def propagate(self):
         # compute the new direction

--- a/molmod/minimizer.py
+++ b/molmod/minimizer.py
@@ -1474,7 +1474,7 @@ class Minimizer(object):
         else:
             converged = False
         # timing
-        end = time.clock()
+        end = time.process_time()
         self._screen("%5.2f" % (end - self.last_end), newline=True)
         self.last_end = end
         # check convergence, part 2


### PR DESCRIPTION
Found during testing yaff for python 3.8 compatibility. 
https://github.com/conda-forge/yaff-feedstock/pull/4