### PR TITLE
Fixes for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
-  matrix:
+  jobs:
   - MYCONDAPY=2.7
-  - MYCONDAPY=3.6
   - MYCONDAPY=3.7
   global:
     # ANACONDA_TOKEN
@@ -15,12 +14,7 @@ env:
 
 # Do not use Travis Python to save some time.
 language: generic
-os:
-  - linux
-  - osx
-osx_image: xcode6.4
-dist: trusty
-sudo: false
+dist: xenial
 
 branches:
   only:
@@ -30,30 +24,20 @@ branches:
 install:
 # Get miniconda. Take the right version, so re-installing python is only needed for 3.5.
 - if [[ "$MYCONDAPY" == "2.7" ]]; then
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh;
-    fi;
+    wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
   else
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-    fi;
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   fi
 - bash miniconda.sh -b -p $HOME/miniconda
 - source ~/miniconda/bin/activate
 - hash -r
 
-# Configure conda and get a few essentials
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-# Get the right python version for building. This only does something for 3.5.
-# Install extra package needed to make things work. Most things can be listed as
+## Configure conda and get a few essentials
+- conda config --set always_yes yes
+# Get the right python version for building. Most things can be listed as
 # dependencies on metal.yaml and setup.py, unless setup.py already imports them.
-# Install conda tools for packaging and uploading
-- conda install python=${MYCONDAPY} numpy cython sphinx conda-build anaconda-client codecov coverage nose conda-verify
+# This also installs conda tools for packaging and uploading
+- conda install python=${MYCONDAPY} conda-build numpy cython conda-verify numpy cython sphinx anaconda-client codecov coverage nose
 # Show conda info for debugging
 - conda info -a
 
@@ -71,8 +55,8 @@ script:
 # PyPI.
 - python setup.py sdist
 
-# Install Conda package
-- conda install --use-local $PYPKG
+# Install Conda package, which is put outside the test env.
+- conda install --use-local ${PYPKG}
 
 # Compile documentation
 - (cd doc; make html)
@@ -88,7 +72,7 @@ after_success:
 deploy:
 - provider: releases
   skip_cleanup: true
-  api_key: ${GITHUB_TOKEN}
+  token: ${GITHUB_TOKEN}
   file: dist/${PYPKG}-${TRAVIS_TAG}.tar.gz
   on:
     repo: ${GITHUB_REPO_NAME}
@@ -97,7 +81,7 @@ deploy:
   prerelease: false
 - provider: releases
   skip_cleanup: true
-  api_key: ${GITHUB_TOKEN}
+  token: ${GITHUB_TOKEN}
   file: dist/${PYPKG}-${TRAVIS_TAG}.tar.gz
   on:
     repo: ${GITHUB_REPO_NAME}
@@ -127,7 +111,7 @@ deploy:
     condition: "$TRAVIS_TAG != *[ab]*"
 - provider: pypi
   skip_cleanup: true
-  user: molmod
+  username: molmod
   password: ${PYPI_PASSWD}
   on:
     repo: ${GITHUB_REPO_NAME}
@@ -135,7 +119,7 @@ deploy:
     condition: "$TRAVIS_TAG != *[ab]* && $MYCONDAPY == 2.7 && $TRAVIS_OS_NAME == linux"
 - provider: pages
   skip_cleanup: true
-  github_token: ${GITHUB_TOKEN}
+  token: ${GITHUB_TOKEN}
   project_name: ${PYPKG}
   local_dir: doc/_build/html
   on:

--- a/molmod/log.py
+++ b/molmod/log.py
@@ -388,11 +388,11 @@ class Timer(object):
 
     def start(self):
         assert self._start is None
-        self._start = time.clock()
+        self._start = time.process_time()
 
     def stop(self):
         assert self._start is not None
-        self.cpu += time.clock() - self._start
+        self.cpu += time.process_time() - self._start
         self._start = None
 
 

--- a/molmod/log.py
+++ b/molmod/log.py
@@ -29,7 +29,10 @@ import os
 import platform
 import datetime
 import getpass
-import time
+try:
+    from time import process_time
+except ImportError:
+    from time import clock as process_time
 import codecs
 import locale
 import functools
@@ -388,11 +391,11 @@ class Timer(object):
 
     def start(self):
         assert self._start is None
-        self._start = time.process_time()
+        self._start = process_time()
 
     def stop(self):
         assert self._start is not None
-        self.cpu += time.process_time() - self._start
+        self.cpu += process_time() - self._start
         self._start = None
 
 

--- a/molmod/minimizer.py
+++ b/molmod/minimizer.py
@@ -63,7 +63,10 @@
 from __future__ import print_function, division
 
 from builtins import range
-import time
+try:
+    from time import process_time
+except ImportError:
+    from time import clock as process_time
 
 import numpy as np
 
@@ -1414,7 +1417,7 @@ class Minimizer(object):
             except ConstraintError:
                 self._screen("CONSTRAINT PROJECT FAILED", newline=True)
                 return False
-        self.last_end = time.process_time()
+        self.last_end = process_time()
 
     def propagate(self):
         # compute the new direction
@@ -1474,7 +1477,7 @@ class Minimizer(object):
         else:
             converged = False
         # timing
-        end = time.process_time()
+        end = process_time()
         self._screen("%5.2f" % (end - self.last_end), newline=True)
         self.last_end = end
         # check convergence, part 2

--- a/molmod/minimizer.py
+++ b/molmod/minimizer.py
@@ -1414,7 +1414,7 @@ class Minimizer(object):
             except ConstraintError:
                 self._screen("CONSTRAINT PROJECT FAILED", newline=True)
                 return False
-        self.last_end = time.clock()
+        self.last_end = time.process_time()
 
     def propagate(self):
         # compute the new direction

--- a/molmod/minimizer.py
+++ b/molmod/minimizer.py
@@ -1474,7 +1474,7 @@ class Minimizer(object):
         else:
             converged = False
         # timing
-        end = time.clock()
+        end = time.process_time()
         self._screen("%5.2f" % (end - self.last_end), newline=True)
         self.last_end = end
         # check convergence, part 2

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -27,8 +27,6 @@ requirements:
 test:
   imports:
     - molmod
-  commands:
-    - conda inspect linkages molmod  # [not win]
 
 about:
   dev_url: https://github.com/molmod/molmod


### PR DESCRIPTION
CI is not working for 3.8 yet due to the lack of an official conda-build release for py38. Testing on OSx is dropped due to lack of interest to keep it working.