### PR TITLE
Fix numpy 1.20 issue

### DIFF
--- a/molmod/io/chk.py
+++ b/molmod/io/chk.py
@@ -142,7 +142,7 @@ def dump_chk(filename, data):
                     raise TypeError('Arrays with fields are not supported.')
                 shape_str = ','.join(str(i) for i in value.shape)
                 if issubclass(value.dtype.type, (str, np.unicode, np.bytes_)):
-                    value = value.astype(np.unicode)
+                    value = value.astype(str)
                     for cell in value.flat:
                         if len(cell) >= 22:
                             raise ValueError('In case of string arrays, a string may contain at most 21 characters.')


### PR DESCRIPTION
Here is an example of this bug: 
```
import numpy as np
a = np.array(["N3"])
print(a.astype(str))
print(a.astype(np.unicode))
```
The first print command works, the second fails with: 
```
/srv/conda/envs/notebook/lib/python3.7/site-packages/ipykernel_launcher.py:1: DeprecationWarning: `np.unciode` is a deprecated alias for `np.compat.unciode`. To silence this warning, use `np.compat.unciode` by itself. In the likely event your code does not need to work on Python 2 you can use the builtin `str` for which `np.compat.unciode` is itself an alias. Doing this will not modify any behaviour and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  """Entry point for launching an IPython kernel.
```
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-c18129268ef1> in <module>
----> 1 a.astype(np.unicode)

ValueError: invalid literal for int() with base 10: 'N3'
```
